### PR TITLE
[CMS PR 41846] Always complete language suffix for menutype in blog sample data

### DIFF
--- a/plugins/sampledata/blog/src/Extension/Blog.php
+++ b/plugins/sampledata/blog/src/Extension/Blog.php
@@ -791,24 +791,27 @@ final class Blog extends CMSPlugin
         }
 
         // Detect language to be used.
-        $language   = Multilanguage::isEnabled() ? $this->getApplication()->getLanguage()->getTag() : '*';
-        $langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
+        $language           = Multilanguage::isEnabled() ? $this->getApplication()->getLanguage()->getTag() : '*';
+        $langSuffixTitle    = ($language !== '*') ? ' (' . $language . ')' : '';
+        $langSuffixMenutype = ($language !== '*') ? '-' . $language : '';
+
+        // Maximum length of menutype 24 - 1 for prefix - lenght of language code suffix
+        $menutypeBaseLength = 23 - strlen($langSuffixMenutype);
 
         // Create the menu types.
         $menuTable = new \Joomla\Component\Menus\Administrator\Table\MenuTypeTable($this->getDatabase());
         $menuTypes = [];
 
         for ($i = 0; $i <= 2; $i++) {
-            $menu = [
+            // Title without language code suffix
+            $titleBase = $this->getApplication()->getLanguage()->_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_MENU_' . $i . '_TITLE');
+
+            $menu  = [
                 'id'          => 0,
-                'title'       => $this->getApplication()->getLanguage()->_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_MENU_' . $i . '_TITLE') . $langSuffix,
+                'title'       => $titleBase . $langSuffixTitle;
                 'description' => $this->getApplication()->getLanguage()->_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_MENUS_MENU_' . $i . '_DESCRIPTION'),
+                'menutype'    => $i . HTMLHelper::_('string.truncate', $titleBase, $menutypeBaseLength, true, false) . $langSuffixMenutype;
             ];
-
-            // Calculate menutype. The number of characters allowed is 24.
-            $type = HTMLHelper::_('string.truncate', $menu['title'], 16, true, false);
-
-            $menu['menutype'] = $i . $type;
 
             try {
                 $menuTable->load();


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/41846 .

### Summary of Changes

This is how I would do it so that the string is shortened before the language string suffix is appended, to make sure that we always have the complete language suffix at the end.

But maybe you have better ideas.

You can use this PR here for your CMS PR, if you want.

But maybe you prefer that I make my own PR?